### PR TITLE
fix single thread

### DIFF
--- a/dehb/optimizers/dehb.py
+++ b/dehb/optimizers/dehb.py
@@ -585,10 +585,11 @@ class DEHB(DEHBBase):
                     # have finished computation and returned its results
                     pass
                 else:
-                    self.logger.debug("{}/{} worker(s) available.".format(
-                        len(self.client.scheduler_info()['workers']) - len(self.futures),
-                        len(self.client.scheduler_info()['workers']))
-                    )
+                    if self.n_workers > 1 and hasattr(self, "client") and isinstance(self.client, Client):
+                        self.logger.debug("{}/{} worker(s) available.".format(
+                            len(self.client.scheduler_info()['workers']) - len(self.futures),
+                            len(self.client.scheduler_info()['workers']))
+                        )
                     # submits job_info to a worker for execution
                     self.submit_job(job_info)
                     if verbose:


### PR DESCRIPTION
Hello,

I had problem while running with `n_workers=1`. `self.client` is not initialized when the `n_workers` is `1` as it is not required but `self.client` is used inside of `DEHB.run` function without a guard which throws `AttributeError: 'NoneType' object has no attribute 'scheduler_info'`. I added a check to fix it.