### PR TITLE
Slurm helper scripts for Dask cluster

### DIFF
--- a/utils/generate_slurm_jobs.py
+++ b/utils/generate_slurm_jobs.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     # generating worker script
     cmd = slurm_header(args, worker=True)
     cmd += setup_cmd
-    cmd += worker_command(scheduler, args.worker_name)
+    cmd += worker_command(scheduler, args.worker_name, args.gpu)
     with open(worker_file, "w") as f:
         f.writelines(cmd)
     print("Saving worker job script to {}".format(worker_file))

--- a/utils/generate_slurm_jobs.py
+++ b/utils/generate_slurm_jobs.py
@@ -12,9 +12,11 @@ def scheduler_command(scheduler_file):
 
 def worker_command(scheduler_file, worker_name, gpu=False, gpu_per_worker=1):
     cmd = "dask-worker --scheduler-file {} --name \"{}_\"$SLURM_ARRAY_TASK_ID --no-nanny"
+    extra_args = " --reconnect --nprocs 1 --nthreads 1"
     cmd = cmd.format(scheduler_file, worker_name)
     if gpu:
         cmd += " --resources \"GPU={}\"".format(gpu_per_worker)
+    cmd += extra_args
     cmd += "\n"
     return cmd
 

--- a/utils/generate_slurm_jobs.py
+++ b/utils/generate_slurm_jobs.py
@@ -1,0 +1,132 @@
+import os
+import argparse
+from pathlib import Path
+
+
+def scheduler_command(scheduler_file):
+    cmd = "dask-scheduler --scheduler-file {}"
+    cmd = cmd.format(scheduler_file)
+    cmd += "\n"
+    return cmd
+
+
+def worker_command(scheduler_file, worker_name, gpu=False, gpu_per_worker=1):
+    cmd = "dask-worker --scheduler-file {} --name \"{}_\"$SLURM_ARRAY_TASK_ID --no-nanny"
+    cmd = cmd.format(scheduler_file, worker_name)
+    if gpu:
+        cmd += " --resources \"GPU={}\"".format(gpu_per_worker)
+    cmd += "\n"
+    return cmd
+
+
+def slurm_header(args, worker=False):
+    cmds = list()
+    # adding shebang
+    cmds.append("#! /bin/bash")
+    node = args.worker_p if worker else args.scheduler_p
+    # adding target node
+    cmds.append("#SBATCH -p {}".format(node))
+    if not worker:
+        # adding cpu request
+        cmds.append("#SBATCH -c {}".format(args.c))
+    # adding memory request
+    cmds.append("#SBATCH --mem {}".format(args.mem))
+    # adding timelimit
+    cmds.append("#SBATCH -t {}".format(args.t))
+    # adding job name
+    suffix = "worker" if worker else "scheduler"
+    cmds.append("#SBATCH -J {}-{}".format(args.J, suffix))
+    if args.gpu and worker:
+        # adding gpu request
+        cmds.append("#SBATCH --gres=gpu:{}".format(args.gpu_per_worker))
+        # making an array job for the workers
+        cmds.append("#SBATCH -a 1-{}".format(args.nworkers))
+    cmds.append("\n")
+    cmds = "\n".join(cmds)
+    return cmds
+
+
+def input_arguments():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "--scheduler_file",
+        default="scheduler.json",
+        type=str,
+        help="The file name storing the Dask cluster connections"
+    )
+    parser.add_argument(
+        "--scheduler_path",
+        default="./scheduler",
+        type=str,
+        help="The path to keep the scheduler.json like files for Dask"
+    )
+    parser.add_argument(
+        "--setup_file",
+        default=None,
+        type=str,
+        help="The path to file that will be sourced to load environment and set path variables"
+    )
+    parser.add_argument(
+        "--output_path", default="./", type=str, help="The path to dump the generated script"
+    )
+    parser.add_argument(
+        "--nworkers", default=10, type=int, help="Number of workers to run"
+    )
+    parser.add_argument(
+        "--worker_name", default="w", type=str, help="Dask worker name prefix"
+    )
+    parser.add_argument(
+        "-c", default=2, type=int, help="CPUs per task requested"
+    )
+    parser.add_argument(
+        "--gpu", default=False, action="store_true", help="If set, the workers request GPUs"
+    )
+    parser.add_argument(
+        "--gpu_per_worker", default=1, type=int, help="Number of GPUs per worker"
+    )
+    parser.add_argument(
+        "--scheduler_p", default=None, required=True, type=str, help="The node to submit schedulers"
+    )
+    parser.add_argument(
+        "--worker_p", default=None, required=True, type=str, help="The node to submit workers"
+    )
+    parser.add_argument(
+        "--mem", default=0, type=int, help="Memory requested"
+    )
+    parser.add_argument(
+        "-t", default="1:00:00", type=str, help="TIMELIMIT"
+    )
+    parser.add_argument(
+        "-J", default="dehb", type=str, help="Prefix to scheduler and worker job names"
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = input_arguments()
+
+    scheduler = Path(args.scheduler_path).absolute() / args.scheduler_file
+    os.makedirs(Path(args.scheduler_path).absolute(), exist_ok=True)
+    output_path = Path(args.output_path).absolute()
+    os.makedirs(Path(args.output_path).absolute(), exist_ok=True)
+    scheduler_file = output_path / "scheduler.sh"
+    worker_file = output_path / "workers.sh"
+    setup_cmd = "source {}\n\n".format(Path(args.setup_file).absolute())
+
+    # generating scheduler script
+    cmd = slurm_header(args, worker=False)
+    cmd += setup_cmd
+    cmd += scheduler_command(scheduler)
+    cmd += "\n"
+    with open(scheduler_file, "w") as f:
+        f.writelines(cmd)
+    print("Saving scheduler job script to {}".format(scheduler_file))
+    # generating worker script
+    cmd = slurm_header(args, worker=True)
+    cmd += setup_cmd
+    cmd += worker_command(scheduler, args.worker_name)
+    with open(worker_file, "w") as f:
+        f.writelines(cmd)
+    print("Saving worker job script to {}".format(worker_file))

--- a/utils/generate_slurm_jobs.py
+++ b/utils/generate_slurm_jobs.py
@@ -57,7 +57,7 @@ def slurm_header(args, worker=False):
         cmds.append("#SBATCH --gres=gpu:{}".format(args.gpu_per_worker))
         # making an array job for the workers
         cmds.append("#SBATCH -a 1-{}".format(args.nworkers))
-    log_pattern = args.slurm_dump_path / "slurm_%j-%a-%x.{}"
+    log_pattern = str(args.slurm_dump_path / "slurm_%j-%a-%x.{}")
     # adding error directory
     cmds.append("#SBATCH -e {}".format(log_pattern.format("err")))
     cmds.append("#SBATCH -o {}".format(log_pattern.format("out")))

--- a/utils/generate_slurm_jobs.py
+++ b/utils/generate_slurm_jobs.py
@@ -31,8 +31,6 @@ def slurm_header(args, worker=False):
     if not worker:
         # adding cpu request
         cmds.append("#SBATCH -c {}".format(args.c))
-    # adding memory request
-    cmds.append("#SBATCH --mem {}".format(args.mem))
     # adding timelimit
     cmds.append("#SBATCH -t {}".format(args.t))
     # adding job name
@@ -93,9 +91,6 @@ def input_arguments():
         "--worker_p", default=None, required=True, type=str, help="The node to submit workers"
     )
     parser.add_argument(
-        "--mem", default=0, type=int, help="Memory requested"
-    )
-    parser.add_argument(
         "-t", default="1:00:00", type=str, help="TIMELIMIT"
     )
     parser.add_argument(
@@ -120,7 +115,7 @@ if __name__ == "__main__":
     # generating scheduler script
     cmd = slurm_header(args, worker=False)
     cmd += setup_cmd
-    cmd += scheduler_command(scheduler)
+    cmd += scheduler_command(scheduler_file=scheduler)
     cmd += "\n"
     with open(scheduler_file, "w") as f:
         f.writelines(cmd)
@@ -128,7 +123,12 @@ if __name__ == "__main__":
     # generating worker script
     cmd = slurm_header(args, worker=True)
     cmd += setup_cmd
-    cmd += worker_command(scheduler, args.worker_name, args.gpu)
+    cmd += worker_command(
+        scheduler_file=scheduler,
+        worker_name=args.worker_name,
+        gpu=args.gpu,
+        gpu_per_worker=args.gpu_per_worker
+    )
     with open(worker_file, "w") as f:
         f.writelines(cmd)
     print("Saving worker job script to {}".format(worker_file))


### PR DESCRIPTION
Requirement to run the generation script:
* a setup script that sets the environment and other related path variables (`setup.sh` in this example)

To generate 2 scripts that can be submitted using `sbatch` to setup a distributed Dask cluster that in principle can be multi-node, and also can be scaled by adding more workers:
```python
python utils/generate_slurm_jobs.py --worker_p [gpu_node] --scheduler_p [cpu_node] --gpu --nworkers 4 --scheduler_path ./scheduler --output_path temp --setup_file ./setup.sh
```

To submit jobs to have the Dask cluster running (sequence and pause is important): 
```bash
sbatch temp/scheduler.sh
# wait 2s or if cluster under heavy load, till scheduler job is alive
sbatch temp/workers.sh
```

To test the  usage of the cluster, the scheduler job logs can show if the workers have connected, or run the example script that comes with DEHB, as an interactive session or another job:
```python
python examples/03_pytorch_mnist_hpo.py --min_budget 1 --max_budget 9 --scheduler_file scheduler/scheduler.json --verbose --runtime 200
```