### PR TITLE
Removes Python upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=[
         '*.tests', '*.tests.*', 'tests.*', 'tests'],
     ),
-    python_requires='>3.5, <=3.9',
+    python_requires='>3.5',
     install_requires=read_file('./requirements.txt').split('\n'),
     test_suite='pytest',
     platforms=['Linux'],


### PR DESCRIPTION
Python is very backward compatible & APIs are deprecated for a long time before being removed.
Unless there is a known issue, we should not put an upper bound.

If a upper bound needs to be put it should be <3.10 so all 3.9.X can be installed.
