### PR TITLE
Add error messages and unit tests for setups where min_budget >= max_budget

### DIFF
--- a/src/dehb/optimizers/dehb.py
+++ b/src/dehb/optimizers/dehb.py
@@ -76,13 +76,8 @@ class DEHBBase:
             if self.max_budget == self.min_budget:
                 self.logger.error(
                     "If you have a fixed fidelity, " \
-                    "you can instead run DE as follows: " \
-                    "AsyncDE(cs=configspace, f=target_function, dimensions=" \
-                    f"{self.dimensions}, pop_size={self.dimensions * 2}, " \
-                    f"max_age={self.max_age}, mutation_factor=" \
-                    f"{self.mutation_factor}, crossover_prob={self.crossover_prob}, "\
-                    f"strategy={self.strategy}, budget={self.max_budget}, " \
-                    f"boundary_fix_type={self.fix_type})")
+                    "you can instead run DE. For more information checkout: " \
+                    "https://automl.github.io/DEHB/references/de")
             raise AssertionError()
         self.eta = eta
         self.min_clip = min_clip

--- a/src/dehb/optimizers/dehb.py
+++ b/src/dehb/optimizers/dehb.py
@@ -28,16 +28,7 @@ class DEHBBase:
                  max_budget=None, eta=None, min_clip=None, max_clip=None,
                  boundary_fix_type='random', max_age=np.inf, **kwargs):
         # Miscellaneous
-        self.output_path = kwargs['output_path'] if 'output_path' in kwargs else './'
-        os.makedirs(self.output_path, exist_ok=True)
-        self.logger = logger
-        log_suffix = time.strftime("%x %X %Z")
-        log_suffix = log_suffix.replace("/", '-').replace(":", '-').replace(" ", '_')
-        self.logger.add(
-            "{}/dehb_{}.log".format(self.output_path, log_suffix),
-            **_logger_props
-        )
-        self.log_filename = "{}/dehb_{}.log".format(self.output_path, log_suffix)
+        self._setup_logger(kwargs)
 
         # Benchmark related variables
         self.cs = cs
@@ -103,6 +94,19 @@ class DEHBBase:
         self.inc_score = np.inf
         self.inc_config = None
         self.history = []
+
+    def _setup_logger(self, kwargs):
+        """Sets up the logger."""
+        self.output_path = kwargs['output_path'] if 'output_path' in kwargs else './'
+        os.makedirs(self.output_path, exist_ok=True)
+        self.logger = logger
+        log_suffix = time.strftime("%x %X %Z")
+        log_suffix = log_suffix.replace("/", '-').replace(":", '-').replace(" ", '_')
+        self.logger.add(
+            "{}/dehb_{}.log".format(self.output_path, log_suffix),
+            **_logger_props
+        )
+        self.log_filename = "{}/dehb_{}.log".format(self.output_path, log_suffix)
 
     def reset(self):
         self.inc_score = np.inf

--- a/src/dehb/optimizers/dehb.py
+++ b/src/dehb/optimizers/dehb.py
@@ -78,10 +78,10 @@ class DEHBBase:
                     "If you have a fixed fidelity, " \
                     "you can instead run DE as follows: " \
                     "AsyncDE(cs=configspace, f=target_function, dimensions=" \
-                    f"{self.dimensions}, pop_size={self.dimensions * 2}," \
+                    f"{self.dimensions}, pop_size={self.dimensions * 2}, " \
                     f"max_age={self.max_age}, mutation_factor=" \
-                    f"{self.mutation_factor}, crossover_prob={self.crossover_prob},"\
-                    f"strategy={self.strategy}, budget={self.max_budget}," \
+                    f"{self.mutation_factor}, crossover_prob={self.crossover_prob}, "\
+                    f"strategy={self.strategy}, budget={self.max_budget}, " \
                     f"boundary_fix_type={self.fix_type})")
             sys.exit()
         self.eta = eta

--- a/src/dehb/optimizers/dehb.py
+++ b/src/dehb/optimizers/dehb.py
@@ -77,7 +77,7 @@ class DEHBBase:
                 self.logger.error(
                     "If you have a fixed fidelity, " \
                     "you can instead run DE as follows: " \
-                    "AsyncDE(confispace, f=target_function, dimensions=" \
+                    "AsyncDE(cs=configspace, f=target_function, dimensions=" \
                     f"{self.dimensions}, pop_size={self.dimensions * 2}," \
                     f"max_age={self.max_age}, mutation_factor=" \
                     f"{self.mutation_factor}, crossover_prob={self.crossover_prob},"\

--- a/src/dehb/optimizers/dehb.py
+++ b/src/dehb/optimizers/dehb.py
@@ -83,7 +83,7 @@ class DEHBBase:
                     f"{self.mutation_factor}, crossover_prob={self.crossover_prob}, "\
                     f"strategy={self.strategy}, budget={self.max_budget}, " \
                     f"boundary_fix_type={self.fix_type})")
-            sys.exit()
+            raise AssertionError()
         self.eta = eta
         self.min_clip = min_clip
         self.max_clip = max_clip

--- a/tests/test_dehb.py
+++ b/tests/test_dehb.py
@@ -40,7 +40,7 @@ def create_toy_optimizer(configspace: ConfigSpace.ConfigurationSpace, min_budget
     dim = len(configspace.get_hyperparameters())
     return DEHB(f=objective_function, cs=configspace, dimensions=dim,
                 min_budget=min_budget,
-                max_budget=max_budget, eta=eta, n_workers=2)
+                max_budget=max_budget, eta=eta, n_workers=1)
 
 
 def objective_function(x: ConfigSpace.Configuration, budget: float, **kwargs):

--- a/tests/test_dehb.py
+++ b/tests/test_dehb.py
@@ -102,6 +102,6 @@ class TestInitialization:
     def test_higher_min_budget(self):
         """Test that verifies, that DEHB breaks if min_budget > max_budget."""
         cs = create_toy_searchspace()
-        with pytest.raises(SystemExit):
+        with pytest.raises(AssertionError):
             create_toy_optimizer(configspace=cs, min_budget=28, max_budget=27, eta=3,
                                         objective_function=objective_function)

--- a/tests/test_dehb.py
+++ b/tests/test_dehb.py
@@ -1,9 +1,11 @@
-import pytest
+import time
 import typing
+
 import ConfigSpace
 import numpy as np
-import time
+import pytest
 from src.dehb.optimizers.dehb import DEHB
+
 
 def create_toy_searchspace():
     """Creates a toy searchspace with a single hyperparameter.
@@ -66,8 +68,7 @@ class TestBudgetExhaustion():
     evaluations and number of brackets to run.
     """
     def test_runtime_exhaustion(self):
-        """Test for runtime budget exhaustion.
-        """
+        """Test for runtime budget exhaustion."""
         cs = create_toy_searchspace()
         dehb = create_toy_optimizer(configspace=cs, min_budget=3, max_budget=27, eta=3,
                                         objective_function=objective_function)
@@ -77,8 +78,7 @@ class TestBudgetExhaustion():
         assert dehb._is_run_budget_exhausted(total_cost=1), "Run budget should be exhausted"
 
     def test_fevals_exhaustion(self):
-        """Test for function evaluations budget exhaustion.
-        """
+        """Test for function evaluations budget exhaustion."""
         cs = create_toy_searchspace()
         dehb = create_toy_optimizer(configspace=cs, min_budget=3, max_budget=27, eta=3,
                                     objective_function=objective_function)
@@ -88,8 +88,7 @@ class TestBudgetExhaustion():
         assert dehb._is_run_budget_exhausted(fevals=1), "Run budget should be exhausted"
 
     def test_brackets_exhaustion(self):
-        """Test for bracket budget exhaustion.
-        """
+        """Test for bracket budget exhaustion."""
         cs = create_toy_searchspace()
         dehb = create_toy_optimizer(configspace=cs, min_budget=3, max_budget=27, eta=3,
                                         objective_function=objective_function)
@@ -98,3 +97,11 @@ class TestBudgetExhaustion():
 
         assert dehb._is_run_budget_exhausted(brackets=1), "Run budget should be exhausted"
 
+class TestInitialization:
+    """Class that bundles all tests regarding the initialization of DEHB."""
+    def test_higher_min_budget(self):
+        """Test that verifies, that DEHB breaks if min_budget > max_budget."""
+        cs = create_toy_searchspace()
+        with pytest.raises(SystemExit):
+            create_toy_optimizer(configspace=cs, min_budget=28, max_budget=27, eta=3,
+                                        objective_function=objective_function)

--- a/tests/test_dehb.py
+++ b/tests/test_dehb.py
@@ -40,7 +40,7 @@ def create_toy_optimizer(configspace: ConfigSpace.ConfigurationSpace, min_budget
     dim = len(configspace.get_hyperparameters())
     return DEHB(f=objective_function, cs=configspace, dimensions=dim,
                 min_budget=min_budget,
-                max_budget=max_budget, eta=eta, n_workers=1)
+                max_budget=max_budget, eta=eta, n_workers=2)
 
 
 def objective_function(x: ConfigSpace.Configuration, budget: float, **kwargs):
@@ -104,4 +104,11 @@ class TestInitialization:
         cs = create_toy_searchspace()
         with pytest.raises(AssertionError):
             create_toy_optimizer(configspace=cs, min_budget=28, max_budget=27, eta=3,
+                                        objective_function=objective_function)
+
+    def test_equal_min_max_budget(self):
+        """Test that verifies, that DEHB breaks if min_budget == max_budget."""
+        cs = create_toy_searchspace()
+        with pytest.raises(AssertionError):
+            create_toy_optimizer(configspace=cs, min_budget=27, max_budget=27, eta=3,
                                         objective_function=objective_function)


### PR DESCRIPTION
Before we simply used an assertion and printed:
```
Only (Max Budget > Min Budget) is supported for DEHB.
```

Now we log an error with same message if ```min_budget <= max_budget```, but we also add an additional error if ```min_budget == max_budget```, guiding the user to use plain DE (values are obviously filled with values specified by the user, apart from configspace and target_function):

```
2023-07-25 16:54:19.802 | ERROR    | src.dehb.optimizers.dehb:__init__:75 - Only (Max Budget > Min Budget) is supported for DEHB.
2023-07-25 16:54:19.803 | ERROR    | src.dehb.optimizers.dehb:__init__:77 - If you have a fixed fidelity, you can instead run DE as follows: AsyncDE(cs=configspace, f=target_function, dimensions=1, pop_size=2, max_age=inf, mutation_factor=0.5, crossover_prob=0.5, strategy=rand1_bin, budget=27, boundary_fix_type=random)
``` 
